### PR TITLE
Fix mobile Explore navigation on property pages

### DIFF
--- a/arriendos.html
+++ b/arriendos.html
@@ -7,22 +7,35 @@
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
-  <div class="navbar">
+  <header class="navbar" data-header>
     <div class="inner container">
-      <div class="brand">
-        <a href="index.html" class="brand-link" aria-label="Inicio Gardet Propiedades">
-          <img src="assets/logo.png" alt="Gardet" />
-        </a>
-        <strong>Gardet Propiedades</strong>
-      </div>
-      <nav>
-        <a href="arriendos.html" class="active">Arriendos</a>
+      <a class="brand" href="index.html">
+        <img src="assets/logo.png" alt="Gardet Propiedades" />
+      </a>
+      <nav class="nav-links" data-nav-desktop>
+        <a href="arriendos.html" class="is-active">Arriendos</a>
         <a href="venta.html">Ventas</a>
         <a href="proyectos.html">Proyectos</a>
         <a href="contacto.html" class="btn btn-primary">Contacto</a>
       </nav>
+      <button class="nav-toggle" type="button" aria-controls="mobile-drawer" aria-expanded="false" data-nav-toggle>
+        <span class="sr-only">Abrir menú principal</span>
+        <span class="nav-toggle__bar nav-toggle__bar--top"></span>
+        <span class="nav-toggle__bar nav-toggle__bar--middle"></span>
+        <span class="nav-toggle__bar nav-toggle__bar--bottom"></span>
+      </button>
     </div>
-  </div>
+    <aside id="mobile-drawer" class="nav-drawer" data-nav-drawer aria-hidden="true">
+      <nav class="nav-drawer__menu">
+        <a href="arriendos.html" class="is-active">Arriendos</a>
+        <a href="venta.html">Ventas</a>
+        <a href="proyectos.html">Proyectos</a>
+        <a href="contacto.html" class="btn btn-primary">Contacto</a>
+      </nav>
+    </aside>
+  </header>
+
+  <div class="drawer-overlay" data-drawer-overlay aria-hidden="true"></div>
 
   <main>
     <section class="section section-theme-canvas">
@@ -92,6 +105,7 @@
   <footer class="footer">
     <p>Gardet Propiedades © 2025 — Todos los derechos reservados</p>
   </footer>
+  <script src="assets/js/header.js" defer></script>
   <script src="assets/js/mobile-fixes.js" defer></script>
   <script src="assets/js/filters.js" defer></script>
 </body>

--- a/contacto.html
+++ b/contacto.html
@@ -7,17 +7,33 @@
 <link rel="stylesheet" href="styles.css"/>
 </head>
 <body class="contact-page">
-<div class="navbar navbar--white">
-  <div class="container nav-inner">
-    <a class="brand" href="index.html"><img src="assets/logo.png" alt="Gardet" class="brand-logo"/></a>
-    <nav class="nav-links">
+<header class="navbar" data-header>
+  <div class="inner container">
+    <a class="brand" href="index.html"><img src="assets/logo.png" alt="Gardet Propiedades" class="brand-logo"/></a>
+    <nav class="nav-links" data-nav-desktop>
       <a href="arriendos.html">Arriendos</a>
       <a href="venta.html">Ventas</a>
       <a href="proyectos.html">Proyectos</a>
-      <a class="btn btn-ghost active" href="contacto.html">Contacto</a>
+      <a class="btn btn-primary is-active" href="contacto.html">Contacto</a>
     </nav>
+    <button class="nav-toggle" type="button" aria-controls="mobile-drawer" aria-expanded="false" data-nav-toggle>
+      <span class="sr-only">Abrir menú principal</span>
+      <span class="nav-toggle__bar nav-toggle__bar--top"></span>
+      <span class="nav-toggle__bar nav-toggle__bar--middle"></span>
+      <span class="nav-toggle__bar nav-toggle__bar--bottom"></span>
+    </button>
   </div>
-</div>
+  <aside id="mobile-drawer" class="nav-drawer" data-nav-drawer aria-hidden="true">
+    <nav class="nav-drawer__menu">
+      <a href="arriendos.html">Arriendos</a>
+      <a href="venta.html">Ventas</a>
+      <a href="proyectos.html">Proyectos</a>
+      <a class="btn btn-primary is-active" href="contacto.html">Contacto</a>
+    </nav>
+  </aside>
+</header>
+
+<div class="drawer-overlay" data-drawer-overlay aria-hidden="true"></div>
 
 <section class="contact-hero">
   <div class="container hero-inner">
@@ -86,6 +102,8 @@
 </section>
 
 <footer class="footer"><p>Gardet Propiedades © 2025 — Todos los derechos reservados</p></footer>
+<script src="assets/js/header.js" defer></script>
+<script src="assets/js/mobile-fixes.js" defer></script>
 <script>
 (function(){
   const P = new URLSearchParams(location.search);

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
   <!-- NAV -->
   <header class="navbar" data-header>
     <div class="inner container">
-      <a class="brand" href="/">
+      <a class="brand" href="index.html">
         <img src="assets/logo.png" alt="Gardet Propiedades"/>
       </a>
       <nav class="nav-links" data-nav-desktop>

--- a/proyectos.html
+++ b/proyectos.html
@@ -9,7 +9,7 @@
 <body>
   <header class="navbar" data-header>
     <div class="inner container">
-      <a class="brand" href="/">
+      <a class="brand" href="index.html">
         <img src="assets/logo.png" alt="Gardet Propiedades" />
       </a>
       <nav class="nav-links" data-nav-desktop>

--- a/styles.css
+++ b/styles.css
@@ -26,6 +26,7 @@ a{color:inherit}
 .navbar .brand img{width:92px;height:auto;max-height:64px;display:block;object-fit:contain;filter:drop-shadow(0 18px 32px rgba(15,23,42,.18))}
 .navbar [data-nav-desktop]{display:flex;align-items:center;gap:24px;flex-wrap:wrap;justify-content:flex-end}
 .navbar [data-nav-desktop] a{color:var(--brand);text-decoration:none;font-weight:500;padding:6px 0;transition:color .2s ease,transform .2s ease;white-space:nowrap}
+.navbar [data-nav-desktop] a.is-active:not(.btn){color:var(--accent-strong);}
 .navbar [data-nav-desktop] a:hover{color:var(--accent-strong)}
 .nav-toggle{display:none;position:relative;z-index:120;width:46px;height:46px;border:1px solid rgba(17,17,17,.12);border-radius:14px;background:#fff;padding:10px;align-items:center;justify-content:center;gap:6px;cursor:pointer;transition:background-color .2s ease,box-shadow .2s ease,border-color .2s ease;flex-direction:column}
 .nav-toggle:focus-visible{outline:2px solid var(--accent);outline-offset:2px}
@@ -40,6 +41,7 @@ a{color:inherit}
 .nav-drawer.is-open{transform:translateY(0);opacity:1;pointer-events:auto}
 .nav-drawer__menu{display:flex;flex-direction:column;width:100%}
 .nav-drawer__menu a{display:flex;align-items:center;justify-content:flex-start;gap:12px;padding:18px 0;border-bottom:1px solid rgba(15,23,42,.12);font-size:20px;font-weight:600;text-decoration:none;color:var(--brand);transition:color .2s ease,background-color .2s ease,padding-left .2s ease}
+.nav-drawer__menu a.is-active:not(.btn){color:var(--accent-strong);}
 .nav-drawer__menu a:first-child{border-top:1px solid rgba(15,23,42,.08)}
 .nav-drawer__menu a:hover{color:#111827;background:rgba(255,255,255,.54);padding-left:10px;box-shadow:0 12px 24px rgba(212,175,55,.18)}
 .nav-drawer__menu a.btn{border-bottom:none;margin-top:28px;justify-content:center;width:100%;background:var(--accent);color:#111;font-weight:700;box-shadow:0 18px 36px rgba(212,175,55,.32)}

--- a/venta.html
+++ b/venta.html
@@ -13,7 +13,7 @@
        Si tu header no es global, puedes copiarlo aquí tal cual. -->
   <header class="navbar" data-header>
     <div class="inner container">
-      <a class="brand" href="/">
+      <a class="brand" href="index.html">
         <img src="assets/logo.png" alt="Gardet Propiedades"/>
       </a>
       <nav class="nav-links" data-nav-desktop>


### PR DESCRIPTION
## Summary
- reuse the shared header structure on the arriendos and contacto pages so the Explore drawer opens and routes correctly on mobile
- highlight the active section in the navigation and ensure all brand links resolve to the home page when served from a subdirectory
- load the navigation behavior script on pages that previously missed it

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68e3d2198f04832188cb696c591ad9c6